### PR TITLE
Fix error with null check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4545,8 +4545,7 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -4673,8 +4672,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4686,7 +4684,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4812,8 +4809,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4946,7 +4942,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4545,7 +4545,8 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -4672,7 +4673,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4684,6 +4686,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4809,7 +4812,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4942,6 +4946,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/components/Book Shelf.js
+++ b/src/components/Book Shelf.js
@@ -5,22 +5,21 @@ class BookShelf extends React.Component {
 state ={}
 
 render(){
+  const books = this.props.shelf.books;
+
   return(
    <div>
     <div className="bookshelf">
       <h2 className="bookshelf-title">Currently Reading</h2>
       <div className="bookshelf-books">
         <ol className="books-grid">
-        {this
-          .props
-          .shelf
-          .books
-          .map(book => (
-            <li key={book.id}>
-           <Book  book ={book} />
-          </li>
-       ))
-      }
+          {
+            books && books.map(book => (
+              <li key={book.id}>
+                <Book  book ={book} />
+              </li>
+            ))
+          }
         </ol>
       </div>
     </div>


### PR DESCRIPTION
Angela, the bug you had in your work was due to a missing `null` check. You were attempting to `map` values of `undefined`. `map` is an Array method, which you were expecting, but since you received `undefined`, it couldn't map it. I put in an inline evaluation. By first checking if `books` evaluated to `true`, I was then able to `map` it.

This is a very common gotcha in SPAs, as a lot of the work is asynchronous and corrected with time. So the condition does not evaluate to `true` when the page loads, but when it does, it loads in the conditional JSX.

Hope this helps. Let me know if you have any questions.